### PR TITLE
fix uvarint helper: sqlite uvarints are big-endian

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -9,3 +9,4 @@
 # Please keep the list sorted.
 
 Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>
+Zellyn Hunter <zellyn@gmail.com>

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -16,3 +16,4 @@
 # Please keep the list sorted.
 
 Sebastien Binet <binet@cern.ch> <seb.binet@gmail.com>
+Zellyn Hunter <zellyn@gmail.com>

--- a/utils.go
+++ b/utils.go
@@ -6,7 +6,6 @@ package sqlite3
 
 import (
 	"bytes"
-	bb "encoding/binary"
 
 	"github.com/gonuts/binary"
 )
@@ -29,5 +28,18 @@ func unmarshal(buf []byte, ptr interface{}) (int64, error) {
 }
 
 func uvarint(data []byte) (uint64, int) {
-	return bb.Uvarint(data)
+	var val uint64
+	for i := 0; i < 8; i++ {
+		if i > len(data)-1 {
+			return 0, 0
+		}
+		val = (val << 7) | uint64(data[i]&0x7f)
+		if data[i] <= 0x80 {
+			return val, i + 1
+		}
+	}
+	if len(data) < 9 {
+		return 0, 0
+	}
+	return (val << 8) | uint64(data[8]), 9
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,0 +1,26 @@
+package sqlite3
+
+import "testing"
+
+func TestUvarint(t *testing.T) {
+	testdata := []struct {
+		in      []byte
+		valWant uint64
+		nWant   int
+	}{
+		{[]byte{0x7f}, 0x7f, 1},
+		{[]byte{0x7f, 0x42}, 0x7f, 1},
+		{[]byte{0x81}, 0x0, 0},
+		{[]byte{0x81, 0x1}, 0x81, 2},
+		{[]byte{0x83, 0x60}, 0x1e0, 2},
+		{[]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff}, 0xffffffffffffffff, 9},
+	}
+
+	for _, tt := range testdata {
+		valGot, nGot := uvarint(tt.in)
+
+		if tt.valWant != valGot || tt.nWant != nGot {
+			t.Errorf("want uvarint(%v) = (%d, %d); got (%d, %d)", tt.in, tt.valWant, tt.nWant, valGot, nGot)
+		}
+	}
+}


### PR DESCRIPTION
The existing code uses encoding/binary's Uvarint function, which
mimics protobuf varints, which are little-endian. Sqlite uses
big-endian varints, and uses all 8 bits of the ninth byte.